### PR TITLE
add wordpress hooks

### DIFF
--- a/plugins/Wordpress/Bootstrap.php
+++ b/plugins/Wordpress/Bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Wordpress;
+
+use DI\Container;
+use Jtl\Connector\Core\Plugin\PluginInterface;
+use Noodlehaus\ConfigInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class Bootstrap implements PluginInterface
+{
+	public function registerListener(ConfigInterface $config, Container $container, EventDispatcher $dispatcher)
+	{
+		do_action('jtlwoo_events_listener',$config, $container, $dispatcher);
+	}
+}

--- a/src/Utilities/SqlTraits/CustomerTrait.php
+++ b/src/Utilities/SqlTraits/CustomerTrait.php
@@ -62,7 +62,8 @@ trait CustomerTrait
         ) {
             $pullGroups = Config::get(Config::OPTIONS_PULL_CUSTOMER_GROUPS, []);
         }
-
+        // filter for other plugins to add or remove customer groups
+        $pullGroups = apply_filters('jtlwoo_pull_customer_groups',$pullGroups);
         return \sprintf("
             SELECT %s
             FROM `%s` um


### PR DESCRIPTION
In my opinion, it is much better if WordPress hooks are used in the plugin so that other plugins can write plugins for it without changing the original plugin code. I have added two hooks now, with which many tasks can be done without modifying the original plugin.