### PR TITLE
Fix bug not finding the table if the table was prefixed

### DIFF
--- a/src/Utilities/SqlTraits/PaymentTrait.php
+++ b/src/Utilities/SqlTraits/PaymentTrait.php
@@ -55,7 +55,7 @@ trait PaymentTrait
             %s
             %s",
                 $select,
-                'wp_wc_orders',
+                $wpdb->prefix . 'wc_orders',
                 $jclp,
                 $jclo,
                 $includeCompletedOrders ? "p.status = 'wc-completed' OR " : '',


### PR DESCRIPTION
This pull request solves sync issues if the woocomerce tables were prefixed