### PR TITLE
Fix Product::setConsiderStock() - must be of type bool, string given

### DIFF
--- a/src/Controllers/ProductController.php
+++ b/src/Controllers/ProductController.php
@@ -132,7 +132,7 @@ class ProductController extends AbstractBaseController implements
                 ->setLength((double)$product->get_length())
                 ->setWidth((double)$product->get_width())
                 ->setShippingWeight((double)$product->get_weight())
-                ->setConsiderStock($product->managing_stock())
+                ->setConsiderStock($product->managing_stock() === 'yes')
                 ->setPermitNegativeStock($product->backorders_allowed())
                 ->setShippingClassId(new Identity((string)$product->get_shipping_class_id()));
 


### PR DESCRIPTION
In woo-jtl-connector/vendor/jtl/connector/src/Model/Product.php the method setConsiderStock expects its argument to be boolean. But the return value from WooCommerce can actually be mixed. In this case the string 'yes' or 'no'. The patch converts 'yes' to boolean true.