### PR TITLE
Load plugins from custom plugins directory

### DIFF
--- a/includes/JtlConnector.php
+++ b/includes/JtlConnector.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use Jtl\Connector\Core\Application\Application;
 use Jtl\Connector\Core\Config\ConfigSchema;
 use Jtl\Connector\Core\Config\FileConfig;
 use Jtl\Connector\Core\Utilities\Validator\Validate;
+use JtlWooCommerceConnector\Application;
 use JtlWooCommerceConnector\Connector;
 use Psr\Log\LogLevel;
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace JtlWooCommerceConnector;
+
+use DI\Container;
+use Jtl\Connector\Core\Application\Application as CoreApplication;
+use Jtl\Connector\Core\Config\CoreConfigInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class Application extends CoreApplication
+{
+    protected function loadPlugins(CoreConfigInterface $config, Container $container, EventDispatcher $eventDispatcher, string $pluginsDir): void
+    {
+        parent::loadPlugins($config, $container, $eventDispatcher, $pluginsDir);
+
+        if (!is_dir(JTLWCC_EXT_CONNECTOR_PLUGIN_DIR)) {
+            return;
+        }
+
+        parent::loadPlugins($config, $container, $eventDispatcher, JTLWCC_EXT_CONNECTOR_PLUGIN_DIR);
+    }
+}


### PR DESCRIPTION
In `woo-jtl-connector.php` the customs plugins directory is only added to the autoloader, but the plugins are never loaded.
This PR will also load the plugins in the custom plugins directory, if it exists.