### PR TITLE
DP-379 - Fix workflows: Add persist-credentials: false to all checkouts

### DIFF
--- a/.github/workflows/auto-draft-pr.yaml
+++ b/.github/workflows/auto-draft-pr.yaml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           sparse-checkout: .github/scripts
 
       - name: Open draft PR

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -13,6 +13,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:
@@ -56,6 +58,8 @@ jobs:
       SVN_URL: https://plugins.svn.wordpress.org/woo-jtl-connector
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install subversion
         run: sudo apt-get update && sudo apt-get install -y subversion

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -21,6 +21,8 @@ jobs:
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - run: git config --global --add safe.directory "${{ github.workspace }}"
 
       - run: composer install --no-progress --no-interaction
@@ -47,6 +49,8 @@ jobs:
         php-version: ['8.1', '8.2', '8.3']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:

--- a/.github/workflows/lint-actions.yaml
+++ b/.github/workflows/lint-actions.yaml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           sparse-checkout: .github
 
       - uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0

--- a/.github/workflows/lint-scripts.yaml
+++ b/.github/workflows/lint-scripts.yaml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           sparse-checkout: .github/scripts
 
       - uses: reviewdog/action-shellcheck@f627b974d3005f993dc36f46d2cdf2684be18e5c # v1.9.0


### PR DESCRIPTION
By default, actions/checkout persists the GITHUB_TOKEN as a git credential helper entry so subsequent steps can push or fetch from GitHub without an explicit token. None of the jobs in this repo require git credentials after the initial checkout - each job authenticates via its own mechanism - so the persisted credential was an unnecessary attack surface: a compromised build step (e.g. via a malicious transitive dependency) could use it to make authenticated API calls or push to the repository.

Changes:
- .github/workflows/check.yaml (status-check, line 23; phpunit, line 51) Added persist-credentials: false to both checkout steps. The status-check job uses the custom CI container image for Composer auth; the phpunit job relies on shivammathur/setup-php which independently configures Composer GitHub OAuth via the GITHUB_TOKEN env var - neither depends on the checkout credential helper.

- .github/workflows/build-and-deploy.yaml (build, line 15; deploy, line 60) Added persist-credentials: false to both checkout steps. The build job uses setup-php for Composer auth (same as phpunit); the deploy job uses explicit SVN_USERNAME/SVN_PASSWORD env vars for all SVN operations and has no dependency on git credentials after checkout.

- .github/workflows/auto-draft-pr.yaml (line 21) Added persist-credentials: false. The gh CLI in the following step reads GH_TOKEN directly from the environment and does not use the git credential store.

- .github/workflows/lint-actions.yaml (line 27) Added persist-credentials: false. reviewdog/action-actionlint uses the built-in GITHUB_TOKEN for PR annotations, not checkout-persisted credentials.

- .github/workflows/lint-scripts.yaml (line 23) Added persist-credentials: false. Same rationale as lint-actions: reviewdog/action-shellcheck authenticates independently.

No functional change. All jobs continue to work correctly because every post-checkout authentication need is already covered by a job- specific mechanism. The GITHUB_TOKEN is no longer left as a reusable credential in the git config after the checkout step completes.