### PR TITLE
fix: set WooCommerce tax display options on plugin activation

### DIFF
--- a/includes/JtlConnectorAdmin.php
+++ b/includes/JtlConnectorAdmin.php
@@ -504,6 +504,22 @@ final class JtlConnectorAdmin //phpcs:ignore PSR1.Classes.ClassDeclaration.Missi
                 Config::set($name, $defaultValue);
             }
         }
+
+        self::setDefaultWooCommerceTaxOptions();
+    }
+
+    /**
+     * @return void
+     */
+    private static function setDefaultWooCommerceTaxOptions(): void
+    {
+        if (\get_option('woocommerce_tax_display_shop') !== 'incl') {
+            \update_option('woocommerce_tax_display_shop', 'incl', true);
+        }
+
+        if (\get_option('woocommerce_tax_display_cart') !== 'incl') {
+            \update_option('woocommerce_tax_display_cart', 'incl', true);
+        }
     }
 
     /**

--- a/includes/JtlConnectorAdmin.php
+++ b/includes/JtlConnectorAdmin.php
@@ -513,11 +513,13 @@ final class JtlConnectorAdmin //phpcs:ignore PSR1.Classes.ClassDeclaration.Missi
      */
     private static function setDefaultWooCommerceTaxOptions(): void
     {
-        if (\get_option('woocommerce_tax_display_shop') !== 'incl') {
+        $shopDisplay = \get_option('woocommerce_tax_display_shop', false);
+        if ($shopDisplay === false) {
             \update_option('woocommerce_tax_display_shop', 'incl', true);
         }
 
-        if (\get_option('woocommerce_tax_display_cart') !== 'incl') {
+        $cartDisplay = \get_option('woocommerce_tax_display_cart', false);
+        if ($cartDisplay === false) {
             \update_option('woocommerce_tax_display_cart', 'incl', true);
         }
     }

--- a/tests/src/JtlConnectorAdminTest.php
+++ b/tests/src/JtlConnectorAdminTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+// phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols
+
 namespace JtlWooCommerceConnector\Tests;
 
 use PHPUnit\Framework\TestCase;
@@ -14,12 +16,18 @@ require_once __DIR__ . '/../../includes/JtlConnectorAdmin.php';
  */
 class JtlConnectorAdminTest extends TestCase
 {
+    /**
+     * @return void
+     */
     protected function setUp(): void
     {
         parent::setUp();
         WP_Mock::setUp();
     }
 
+    /**
+     * @return void
+     */
     protected function tearDown(): void
     {
         WP_Mock::tearDown();
@@ -56,7 +64,7 @@ class JtlConnectorAdminTest extends TestCase
         ]);
 
         $reflection = new \ReflectionClass(\JtlConnectorAdmin::class);
-        $method = $reflection->getMethod('setDefaultWooCommerceTaxOptions');
+        $method     = $reflection->getMethod('setDefaultWooCommerceTaxOptions');
         $method->invoke(null);
 
         \Mockery::close();
@@ -87,7 +95,7 @@ class JtlConnectorAdminTest extends TestCase
         ]);
 
         $reflection = new \ReflectionClass(\JtlConnectorAdmin::class);
-        $method = $reflection->getMethod('setDefaultWooCommerceTaxOptions');
+        $method     = $reflection->getMethod('setDefaultWooCommerceTaxOptions');
         $method->invoke(null);
 
         \Mockery::close();

--- a/tests/src/JtlConnectorAdminTest.php
+++ b/tests/src/JtlConnectorAdminTest.php
@@ -43,14 +43,14 @@ class JtlConnectorAdminTest extends TestCase
     {
         WP_Mock::userFunction('get_option', [
             'times' => 1,
-            'args' => ['woocommerce_tax_display_shop'],
-            'return' => 'excl',
+            'args' => ['woocommerce_tax_display_shop', false],
+            'return' => false,
         ]);
 
         WP_Mock::userFunction('get_option', [
             'times' => 1,
-            'args' => ['woocommerce_tax_display_cart'],
-            'return' => 'excl',
+            'args' => ['woocommerce_tax_display_cart', false],
+            'return' => false,
         ]);
 
         WP_Mock::userFunction('update_option', [
@@ -79,13 +79,13 @@ class JtlConnectorAdminTest extends TestCase
     {
         WP_Mock::userFunction('get_option', [
             'times' => 1,
-            'args' => ['woocommerce_tax_display_shop'],
+            'args' => ['woocommerce_tax_display_shop', false],
             'return' => 'incl',
         ]);
 
         WP_Mock::userFunction('get_option', [
             'times' => 1,
-            'args' => ['woocommerce_tax_display_cart'],
+            'args' => ['woocommerce_tax_display_cart', false],
             'return' => 'incl',
         ]);
 

--- a/tests/src/JtlConnectorAdminTest.php
+++ b/tests/src/JtlConnectorAdminTest.php
@@ -67,7 +67,6 @@ class JtlConnectorAdminTest extends TestCase
         $method     = $reflection->getMethod('setDefaultWooCommerceTaxOptions');
         $method->invoke(null);
 
-        \Mockery::close();
         $this->addToAssertionCount(1);
     }
 

--- a/tests/src/JtlConnectorAdminTest.php
+++ b/tests/src/JtlConnectorAdminTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JtlWooCommerceConnector\Tests;
+
+use PHPUnit\Framework\TestCase;
+use WP_Mock;
+
+require_once __DIR__ . '/../../includes/JtlConnectorAdmin.php';
+
+/**
+ * @covers \JtlConnectorAdmin
+ */
+class JtlConnectorAdminTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        WP_Mock::tearDown();
+        parent::tearDown();
+    }
+
+    /**
+     * @covers \JtlConnectorAdmin::setDefaultWooCommerceTaxOptions
+     * @return void
+     * @throws \ReflectionException
+     */
+    public function testSetDefaultWooCommerceTaxOptionsSetsValuesOnFirstActivation(): void
+    {
+        WP_Mock::userFunction('get_option', [
+            'times' => 1,
+            'args' => ['woocommerce_tax_display_shop'],
+            'return' => 'excl',
+        ]);
+
+        WP_Mock::userFunction('get_option', [
+            'times' => 1,
+            'args' => ['woocommerce_tax_display_cart'],
+            'return' => 'excl',
+        ]);
+
+        WP_Mock::userFunction('update_option', [
+            'times' => 1,
+            'args' => ['woocommerce_tax_display_shop', 'incl', true],
+        ]);
+
+        WP_Mock::userFunction('update_option', [
+            'times' => 1,
+            'args' => ['woocommerce_tax_display_cart', 'incl', true],
+        ]);
+
+        $reflection = new \ReflectionClass(\JtlConnectorAdmin::class);
+        $method = $reflection->getMethod('setDefaultWooCommerceTaxOptions');
+        $method->invoke(null);
+
+        \Mockery::close();
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @covers \JtlConnectorAdmin::setDefaultWooCommerceTaxOptions
+     * @return void
+     * @throws \ReflectionException
+     */
+    public function testSetDefaultWooCommerceTaxOptionsDoesNotOverwriteOnReActivation(): void
+    {
+        WP_Mock::userFunction('get_option', [
+            'times' => 1,
+            'args' => ['woocommerce_tax_display_shop'],
+            'return' => 'incl',
+        ]);
+
+        WP_Mock::userFunction('get_option', [
+            'times' => 1,
+            'args' => ['woocommerce_tax_display_cart'],
+            'return' => 'incl',
+        ]);
+
+        WP_Mock::userFunction('update_option', [
+            'times' => 0,
+        ]);
+
+        $reflection = new \ReflectionClass(\JtlConnectorAdmin::class);
+        $method = $reflection->getMethod('setDefaultWooCommerceTaxOptions');
+        $method->invoke(null);
+
+        \Mockery::close();
+        $this->addToAssertionCount(1);
+    }
+}


### PR DESCRIPTION
During plugin activation, woocommerce_tax_display_shop and woocommerce_tax_display_cart are now set to 'incl' (taxes included), ensuring correct display when net price input is configured.

Options are only set if not already configured to 'incl', preventing overwrite of existing settings on re-activation.