### PR TITLE
Fix WooCommerce tax display options not being corrected on install (CO-3447)

### DIFF
--- a/includes/JtlConnectorAdmin.php
+++ b/includes/JtlConnectorAdmin.php
@@ -505,6 +505,8 @@ final class JtlConnectorAdmin //phpcs:ignore PSR1.Classes.ClassDeclaration.Missi
      */
     private static function initDefaultConfigValues(string $buildVersion): void
     {
+        $isFirstInstall = self::isFirstInstall();
+
         Config::set(Config::OPTIONS_TOKEN, self::create_password());
         Config::set(Config::OPTIONS_INSTALLED_VERSION, $buildVersion);
 
@@ -514,21 +516,34 @@ final class JtlConnectorAdmin //phpcs:ignore PSR1.Classes.ClassDeclaration.Missi
             }
         }
 
-        self::setDefaultWooCommerceTaxOptions();
+        if ($isFirstInstall) {
+            self::setDefaultWooCommerceTaxOptions();
+        }
     }
 
     /**
+     * @return bool
+     */
+    private static function isFirstInstall(): bool
+    {
+        return Config::get(Config::OPTIONS_INSTALLED_VERSION) === null;
+    }
+
+    /**
+     * WooCommerce writes its own default of 'excl' for these options during its own
+     * installation, so an explicit 'incl' has to be forced once on first activation of
+     * this plugin. Gated behind $isFirstInstall so a later, deliberate change by the
+     * shop owner is not reverted on every plugin re-activation.
+     *
      * @return void
      */
     private static function setDefaultWooCommerceTaxOptions(): void
     {
-        $shopDisplay = \get_option('woocommerce_tax_display_shop', false);
-        if ($shopDisplay === false) {
+        if (\get_option('woocommerce_tax_display_shop') !== 'incl') {
             \update_option('woocommerce_tax_display_shop', 'incl', true);
         }
 
-        $cartDisplay = \get_option('woocommerce_tax_display_cart', false);
-        if ($cartDisplay === false) {
+        if (\get_option('woocommerce_tax_display_cart') !== 'incl') {
             \update_option('woocommerce_tax_display_cart', 'incl', true);
         }
     }

--- a/tests/src/JtlConnectorAdminTest.php
+++ b/tests/src/JtlConnectorAdminTest.php
@@ -39,18 +39,59 @@ class JtlConnectorAdminTest extends TestCase
      * @return void
      * @throws \ReflectionException
      */
-    public function testSetDefaultWooCommerceTaxOptionsSetsValuesOnFirstActivation(): void
+    public function testSetDefaultWooCommerceTaxOptionsSetsValuesWhenOptionsDoNotExistYet(): void
     {
         WP_Mock::userFunction('get_option', [
             'times' => 1,
-            'args' => ['woocommerce_tax_display_shop', false],
+            'args' => ['woocommerce_tax_display_shop'],
             'return' => false,
         ]);
 
         WP_Mock::userFunction('get_option', [
             'times' => 1,
-            'args' => ['woocommerce_tax_display_cart', false],
+            'args' => ['woocommerce_tax_display_cart'],
             'return' => false,
+        ]);
+
+        WP_Mock::userFunction('update_option', [
+            'times' => 1,
+            'args' => ['woocommerce_tax_display_shop', 'incl', true],
+        ]);
+
+        WP_Mock::userFunction('update_option', [
+            'times' => 1,
+            'args' => ['woocommerce_tax_display_cart', 'incl', true],
+        ]);
+
+        $reflection = new \ReflectionClass(\JtlConnectorAdmin::class);
+        $method     = $reflection->getMethod('setDefaultWooCommerceTaxOptions');
+        $method->invoke(null);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * Regression test for CO-3447: WooCommerce writes its own 'excl' default for these
+     * options during its own installation, so get_option() never returns false on a real
+     * install. The fix has to correct that pre-existing 'excl' value, not just handle the
+     * (rarely occurring) case where the option is entirely unset.
+     *
+     * @covers \JtlConnectorAdmin::setDefaultWooCommerceTaxOptions
+     * @return void
+     * @throws \ReflectionException
+     */
+    public function testSetDefaultWooCommerceTaxOptionsCorrectsWooCommerceDefaultExclValue(): void
+    {
+        WP_Mock::userFunction('get_option', [
+            'times' => 1,
+            'args' => ['woocommerce_tax_display_shop'],
+            'return' => 'excl',
+        ]);
+
+        WP_Mock::userFunction('get_option', [
+            'times' => 1,
+            'args' => ['woocommerce_tax_display_cart'],
+            'return' => 'excl',
         ]);
 
         WP_Mock::userFunction('update_option', [
@@ -75,17 +116,17 @@ class JtlConnectorAdminTest extends TestCase
      * @return void
      * @throws \ReflectionException
      */
-    public function testSetDefaultWooCommerceTaxOptionsDoesNotOverwriteOnReActivation(): void
+    public function testSetDefaultWooCommerceTaxOptionsDoesNotOverwriteWhenAlreadyIncl(): void
     {
         WP_Mock::userFunction('get_option', [
             'times' => 1,
-            'args' => ['woocommerce_tax_display_shop', false],
+            'args' => ['woocommerce_tax_display_shop'],
             'return' => 'incl',
         ]);
 
         WP_Mock::userFunction('get_option', [
             'times' => 1,
-            'args' => ['woocommerce_tax_display_cart', false],
+            'args' => ['woocommerce_tax_display_cart'],
             'return' => 'incl',
         ]);
 
@@ -99,5 +140,43 @@ class JtlConnectorAdminTest extends TestCase
 
         \Mockery::close();
         $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @covers \JtlConnectorAdmin::isFirstInstall
+     * @return void
+     * @throws \ReflectionException
+     */
+    public function testIsFirstInstallReturnsTrueWhenNoVersionIsStoredYet(): void
+    {
+        WP_Mock::userFunction('get_option', [
+            'times' => 1,
+            'args' => ['jtlconnector_installed_version', null],
+            'return' => null,
+        ]);
+
+        $reflection = new \ReflectionClass(\JtlConnectorAdmin::class);
+        $method     = $reflection->getMethod('isFirstInstall');
+
+        $this->assertTrue($method->invoke(null));
+    }
+
+    /**
+     * @covers \JtlConnectorAdmin::isFirstInstall
+     * @return void
+     * @throws \ReflectionException
+     */
+    public function testIsFirstInstallReturnsFalseWhenVersionIsAlreadyStored(): void
+    {
+        WP_Mock::userFunction('get_option', [
+            'times' => 1,
+            'args' => ['jtlconnector_installed_version', null],
+            'return' => '1.0.0',
+        ]);
+
+        $reflection = new \ReflectionClass(\JtlConnectorAdmin::class);
+        $method     = $reflection->getMethod('isFirstInstall');
+
+        $this->assertFalse($method->invoke(null));
     }
 }


### PR DESCRIPTION
## Summary
- QA reported on CO-3447 that the `woocommerce_tax_display_shop`/`woocommerce_tax_display_cart` fix from PR #51 doesn't work on a real install: WooCommerce already writes its own `'excl'` default into `wp_options` before the connector's activation hook runs, so the `get_option(..., false) === false` check introduced in a later "potential fix for pull request finding" commit never triggers.
- Restores the `!== 'incl'` comparison so the pre-existing `'excl'` default is actually corrected to `'incl'`.
- Additionally gates the correction behind a new `isFirstInstall()` check (based on `Config::OPTIONS_INSTALLED_VERSION`), so a shop owner's deliberate later change isn't reverted every time the plugin is re-activated — the concern the weakened check was originally trying (incorrectly) to address.

## Test plan
- [x] `vendor/bin/phpunit tests/src/JtlConnectorAdminTest.php` — new regression test covers the WooCommerce `'excl'`-default scenario, plus tests for `isFirstInstall()`
- [x] `composer run phpcs` / `composer run phpstan` — clean
- [x] Full `vendor/bin/phpunit` run — no new failures (2 pre-existing unrelated failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)